### PR TITLE
feat : AI 클린 봇 기능 연결

### DIFF
--- a/src/components/comment/CommentSheet.vue
+++ b/src/components/comment/CommentSheet.vue
@@ -347,7 +347,8 @@ const handleUpdate = async (commentId, parentId = null) => {
 
     } catch (error) {
         console.error("Failed to update comment", error);
-        toastStore.addToast('댓글 수정에 실패했습니다.', 'error');
+        const message = error.response?.data?.message || '댓글 수정에 실패했습니다.';
+        toastStore.addToast(message, 'error');
     }
 };
 
@@ -380,7 +381,8 @@ const handleCreate = async () => {
 
         } catch (error) {
             console.error("Failed to post reply", error);
-            toastStore.addToast('답글 작성에 실패했습니다.', 'error');
+            const message = error.response?.data?.message || '답글 작성에 실패했습니다.';
+            toastStore.addToast(message, 'error');
         }
         return;
     }
@@ -404,7 +406,9 @@ const handleCreate = async () => {
 
     } catch (error) {
         console.error("Failed to post comment", error);
-        toastStore.addToast('댓글 작성에 실패했습니다.', 'error');
+        
+        const message = error.response?.data?.message || '댓글 작성에 실패했습니다.';
+        toastStore.addToast(message, 'error');
     }
 };
 


### PR DESCRIPTION
## 📌 개요
- AI 클린 봇에 의해 댓글이 차단되었을 때, 구체적인 차단 사유를 사용자에게 안내하도록 개선했습니다.
## 👩‍💻 작업 내용
1. **CommentSheet.vue 에러 핸들링 개선**
   - API 호출(댓글 작성, 수정, 답글) 실패 시, 백엔드로부터 전달받은 `error.response.data.message`를 확인하도록 수정했습니다.
   - 서버에서 구체적인 에러 메시지가 올 경우 해당 내용을 토스트(Toast) 메시지로 출력하고, 없을 경우 기존 기본 메시지를 출력합니다.
## 🛠️ 기술적 의사결정
- **구체적 에러 메시지 노출**: 기존에는 "작성에 실패했습니다"라는 포괄적인 메시지만 출력되어, 사용자가 AI 정책 위반으로 차단된 것인지 서버 오류인지 구분하기 어려웠습니다. 백엔드 예외 메시지를 그대로 노출하여 사용자가 원인을 명확히 인지하고 행동을 수정할 수 있도록 UX를 개선했습니다.
## ✅ 테스트 결과
- 욕설이 포함된 댓글 작성 시도 시, "AI 클린봇: 욕설이나 부적절한 내용이 감지되었습니다."라는 토스트 메시지가 정상 출력됨을 확인했습니다.
## 🔗 관련 이슈
- #