### PR TITLE
feat : 숏폼 영상 공유 기능 구현

### DIFF
--- a/src/views/ShortsTab.vue
+++ b/src/views/ShortsTab.vue
@@ -83,7 +83,7 @@
 
                         <!-- Share -->
                         <div class="d-flex flex-column align-items-center">
-                             <button class="btn btn-icon text-white p-0">
+                             <button @click="handleShare(video)" class="btn btn-icon text-white p-0">
                                 <i class="bi bi-share-fill fs-1 shadow-icon"></i>
                             </button>
                             <span class="small fw-bold text-shadow">공유</span>
@@ -296,6 +296,26 @@ const handleUpdateCount = ({ videoId, delta }) => {
         }
         video.commentCount += delta;
         if (video.commentCount < 0) video.commentCount = 0;
+    }
+};
+
+const handleShare = async (video) => {
+    try {
+        const id = getYoutubeId(video.videoUrl);
+        if (!id) {
+            toastStore.addToast('공유할 수 없는 영상입니다.', 'error');
+            return;
+        }
+
+        const shortsUrl = `https://www.youtube.com/shorts/${id}`;
+        
+        // Clipboard API requires secure context (HTTPS) or localhost
+        await navigator.clipboard.writeText(shortsUrl);
+        
+        toastStore.addToast('링크가 클립보드에 복사되었습니다.', 'success');
+    } catch (error) {
+        console.error('Share failed:', error);
+        toastStore.addToast('클립보드 복사에 실패했습니다.', 'error');
     }
 };
 </script>


### PR DESCRIPTION
## 📌 개요
- 숏폼 영상 시청 중 유튜브 쇼츠 링크를 간편하게 복사할 수 있는 공유 기능 구현

## 👩‍💻 작업 내용
1. **영상 공유 버튼 동작 구현**: `ShortsTab`에서 공유 아이콘 클릭 시 해당 영상의 YouTube Shorts URL 생성 (`https://www.youtube.com/shorts/{videoId}`)
2. **클립보드 복사**: `navigator.clipboard.writeText` API를 사용하여 URL을 사용자 클립보드에 즉시 복사
3. **사용자 피드백**: 복사 성공/실패 여부를 토스트 메시지(`Toast`)로 안내하여 사용자 경험 향상

## 🛠️ 기술적 의사결정
- **Clipboard API**: 별도의 공유 모달을 띄우는 대신 클립보드에 바로 복사하는 방식을 택하여, 사용자가 즉시 메신저 등에 붙여넣기 할 수 있게 Fast Interaction을 유도했습니다.

## ✅ 테스트 결과
- 공유 버튼 클릭 시 "링크가 클립보드에 복사되었습니다." 알림 발생 확인
- 클립보드에 `https://www.youtube.com/shorts/...` 형식의 링크가 정상적으로 복사됨을 확인

## 🔗 관련 이슈
- #16