### PR TITLE
feat : 쇼츠 조회수 증가 구현

### DIFF
--- a/src/views/ShortsTab.vue
+++ b/src/views/ShortsTab.vue
@@ -221,7 +221,27 @@ onMounted(async () => {
             videoItems.value.forEach(el => observer.observe(el));
         }
     }, { immediate: true });
+
+    // 6. Increment View Count on Active Index Change
+    watch(activeIndex, (newIndex) => {
+        if (videoStore.videos.length > newIndex) {
+            const videoId = videoStore.videos[newIndex].videoId;
+            incrementViewCount(videoId);
+        }
+    }, { immediate: true });
 });
+
+const incrementViewCount = async (videoId) => {
+    try {
+        // Fire and forget - just to trigger backend increment
+        await getVideoDetail(videoId);
+        // Optionally update local view count if we want real-time feedback
+        // const video = videoStore.videos.find(v => v.videoId === videoId);
+        // if(video) video.viewCount++; 
+    } catch (e) {
+        console.error("Failed to increment view count", e);
+    }
+};
 
 
 


### PR DESCRIPTION
## 📌 개요
- 쇼츠 영상 시청 시 조회수가 증가하지 않는 문제를 해결하기 위한 프론트엔드 트리거 구현

## 👩‍💻 작업 내용
1. **쇼츠 탭 로직 개선 [ShortsTab.vue]**
   - `activeIndex` (현재 보고 있는 영상 인덱스) 변화를 감지하는 Watcher 추가
   - 스크롤을 통해 새로운 영상이 화면에 잡히면, 해당 영상의`videoId`를 이용해 [getVideoDetail] API를 호출 (Fire-and-forget 방식)
2. **API 활용**
   - 기존의 [getVideoDetail] API가 호출 시 백엔드에서 조회수를 1 증가시킨다는 점을 활용하여, 별도의 조회수 전용 API 생성 없이 기존 로직 재사용
  
## 🛠️ 기술적 의사결정
- **이벤트 트리거 시점 (Scroll vs Click)**:
  - 쇼츠 UI 특성상 영상을 클릭해서 들어가는 것이 아니라 스크롤로 넘기며 시청하므로, `IntersectionObserver`에 의해 `activeIndex`가 변경되는 순간을 '시청 시작'으로 간주하여 조회수를 카운팅하도록 결정했습니다.
 
## ✅ 테스트 결과
- 쇼츠 피드에서 다음 영상으로 스크롤 넘김 시 네트워크 탭에서 `GET /video/{id}` 호출 발생 확인
- DB 및 화면 UI에서 조회수 증가 확인
## 🔗 관련 이슈
- #23